### PR TITLE
Improve progress bar

### DIFF
--- a/src/main/java/com/smartbear/tcpbench/Query.java
+++ b/src/main/java/com/smartbear/tcpbench/Query.java
@@ -8,7 +8,7 @@ public interface Query {
     /**
      * @return all test cycles, chronologically ordered
      */
-    List<String> getOrderedTestCycleIds();
+    List<String> getOrderedFailingTestCycleIds();
 
     /**
      * @param testCycleId the test cycle id

--- a/src/main/java/com/smartbear/tcpbench/TcpEngine.java
+++ b/src/main/java/com/smartbear/tcpbench/TcpEngine.java
@@ -9,11 +9,11 @@ public interface TcpEngine {
      * Define a test cycle
      *
      * @param testCycleId the test cycle ID
-     * @param verdicts the actual test results
-     * @param query an object to extract additional information, if necessary
+     * @param verdicts    the actual test results
+     * @param query       an object to extract additional information, if necessary
      * @throws Exception if anything went wrong
      */
-    void defineTestCycle(String testCycleId, List<Verdict> verdicts, Query query) throws Exception;
+    void defineTestCycle(String testCycleId, List<Verdict> verdicts, Query query);
 
     /**
      * Perform a tcp opertation
@@ -22,14 +22,14 @@ public interface TcpEngine {
      * @return the ordered test IDs for the test cycle, or null if no ordering could be determined
      * @throws Exception if anything went wrong
      */
-    List<String> getOrdering(String testCycleId) throws Exception;
+    List<String> getOrdering(String testCycleId);
 
     /**
      * Train the engine
      *
      * @param testCycleId the test cycle ID
-     * @param verdicts the actual test results
+     * @param verdicts    the actual test results
      * @throws Exception if anything went wrong
      */
-    void train(String testCycleId, List<Verdict> verdicts) throws Exception;
+    void train(String testCycleId, List<Verdict> verdicts);
 }

--- a/src/main/java/com/smartbear/tcpbench/engines/AbstractEngine.java
+++ b/src/main/java/com/smartbear/tcpbench/engines/AbstractEngine.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public abstract class DefaultEngine implements TcpEngine {
+public abstract class AbstractEngine implements TcpEngine {
     private final Map<String, List<Verdict>> verdictsByTestCycleId = new HashMap<>();
 
     @Override
@@ -16,12 +16,12 @@ public abstract class DefaultEngine implements TcpEngine {
     }
 
     @Override
-    public void defineTestCycle(String testCycleId, List<Verdict> verdicts, Query query) throws Exception {
+    public void defineTestCycle(String testCycleId, List<Verdict> verdicts, Query query) {
         verdictsByTestCycleId.put(testCycleId, verdicts);
     }
 
     @Override
-    public void train(String testCycleId, List<Verdict> verdicts) throws Exception {
+    public void train(String testCycleId, List<Verdict> verdicts) {
 
     }
 

--- a/src/main/java/com/smartbear/tcpbench/engines/InitialOrder.java
+++ b/src/main/java/com/smartbear/tcpbench/engines/InitialOrder.java
@@ -5,7 +5,7 @@ import com.smartbear.tcpbench.Verdict;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class InitialOrder extends DefaultEngine {
+public class InitialOrder extends AbstractEngine {
     @Override
     public List<String> getOrdering(String testCycleId) {
         return getVerdicts(testCycleId).stream().map(Verdict::getTestId).collect(Collectors.toList());

--- a/src/main/java/com/smartbear/tcpbench/engines/OptimalOrder.java
+++ b/src/main/java/com/smartbear/tcpbench/engines/OptimalOrder.java
@@ -5,7 +5,7 @@ import com.smartbear.tcpbench.Verdict;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class OptimalOrder extends DefaultEngine {
+public class OptimalOrder extends AbstractEngine {
     @Override
     public List<String> getOrdering(String testCycleId) {
         return getVerdicts(testCycleId).stream()

--- a/src/main/java/com/smartbear/tcpbench/engines/RandomOrder.java
+++ b/src/main/java/com/smartbear/tcpbench/engines/RandomOrder.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-public class RandomOrder extends DefaultEngine {
+public class RandomOrder extends AbstractEngine {
     private final Random random = new Random(98765);
 
     @Override

--- a/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
+++ b/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
@@ -49,8 +49,9 @@ public class RtpTorrentQuery implements Query {
     }
 
     @Override
-    public List<String> getOrderedTestCycleIds() {
+    public List<String> getOrderedFailingTestCycleIds() {
         return testsTable.stringColumn("travisJobId")
+                .where(testsTable.intColumn("failures").isGreaterThan(0))
                 .unique()
                 .sorted(Comparator.comparingInt(Integer::parseInt))
                 .asList();


### PR DESCRIPTION
Wit this change, the test cycle Ids is filtered down to only failing cycles in the query (rather than in main). This makes it possible to known in advance how many test cycles we're processing. 