### PR TITLE
Using JGit to obtain commit info -> get nbr of insertions, deletions,…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>6.1.0.202203080745-r</version>
+        </dependency>
+        <dependency>
             <groupId>tech.tablesaw</groupId>
             <artifactId>tablesaw-core</artifactId>
             <version>0.42.0</version>

--- a/src/main/java/com/smartbear/tcpbench/Changes.java
+++ b/src/main/java/com/smartbear/tcpbench/Changes.java
@@ -1,0 +1,38 @@
+package com.smartbear.tcpbench;
+
+public class Changes {
+    private final int changedFiles;
+    private final int linesAdded;
+    private final int linesDeleted;
+    private final int timeDiff;
+
+    public Changes() {
+        this.changedFiles = 0;
+        this.linesAdded = 0;
+        this.linesDeleted = 0;
+        this.timeDiff = 0;
+    }
+
+    public Changes(int changedFiles, int linesAdded, int linesDeleted, int timeDiff) {
+        this.changedFiles = changedFiles;
+        this.linesAdded = linesAdded;
+        this.linesDeleted = linesDeleted;
+        this.timeDiff = timeDiff;
+    }
+
+    public int getChangedFiles() {
+        return changedFiles;
+    }
+
+    public int getLinesAdded() {
+        return linesAdded;
+    }
+
+    public int getLinesDeleted() {
+        return linesDeleted;
+    }
+
+    public int getTimeDiff() {
+        return timeDiff;
+    }
+}

--- a/src/main/java/com/smartbear/tcpbench/Query.java
+++ b/src/main/java/com/smartbear/tcpbench/Query.java
@@ -27,11 +27,19 @@ public interface Query {
     List<String> getShas(String testCycleId);
 
     /**
-     * @param sha a git sha
+     * @param sha    a git sha
      * @param regexp a filter for file names to return
      * @return the paths of the files modifies in the commit, after the regexp filter is applied
      */
     Set<String> getModifiedFiles(String sha, String regexp);
+
+    /**
+     * @param newSha the old sha
+     * @param oldSha the new sha
+     * @param regexp a filter for file
+     * @return the diff between two commits
+     */
+    Changes getChanges(String oldSha, String newSha, String regexp);
 
     /**
      * @return the path to the Git repository

--- a/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
+++ b/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
@@ -8,6 +8,7 @@ import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.diff.Edit;
 import org.eclipse.jgit.diff.RawTextComparator;
+import org.eclipse.jgit.errors.AmbiguousObjectException;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -126,8 +127,11 @@ public class RtpTorrentQuery implements Query {
                 }
             }
             return new Changes(changedFiles, linesAdded, linesDeleted, timeDiff);
-        } catch (IOException e) {
+        } catch (AmbiguousObjectException e) {
+            // unable to find commit
             return new Changes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
+++ b/src/main/java/com/smartbear/tcpbench/rtptorrent/RtpTorrentQuery.java
@@ -120,10 +120,8 @@ public class RtpTorrentQuery implements Query {
             changedFiles = diffEntries.size();
             for (DiffEntry diffEntry : diffEntries) {
                 for (Edit edit : diffFormatter.toFileHeader(diffEntry).toEditList()) {
-                    if (edit.getType() != Edit.Type.REPLACE) {
-                        linesDeleted += edit.getEndA() - edit.getBeginA();
-                        linesAdded += edit.getEndB() - edit.getBeginB();
-                    }
+                    linesDeleted += edit.getEndA() - edit.getBeginA();
+                    linesAdded += edit.getEndB() - edit.getBeginB();
                 }
             }
             return new Changes(changedFiles, linesAdded, linesDeleted, timeDiff);


### PR DESCRIPTION
Using JGit to obtain commit info -> get nbr of insertions, deletions, modified files and the time difference between cycle.
Change the regex ".java$" to ".*.java$"

Get the number of modified files using *-patches.csv in less precise than using Git diff: a single file can be modified by multiple commits in the same cycle and falsify the count of modified files. Using git diff allow us to compare the changes between the last commits of two consecutive builds.

The regex ".java$" always return 0 files -> change it to ".*.java$"